### PR TITLE
OTP-22, remove hipe flag

### DIFF
--- a/src/brine_format.erl
+++ b/src/brine_format.erl
@@ -20,7 +20,6 @@
 
 -module(brine_format).
 
--compile([native, {hipe, [o3]}]).
 -compile({inline, [hex/1]}).
 
 -define(H(X), (hex(X)):16).


### PR DESCRIPTION
OTP-22 has issues with HiPE for some binary match functions, we don't use the formatters anyway, not that it looks particularly critical.